### PR TITLE
AWS env variables document

### DIFF
--- a/aws.md
+++ b/aws.md
@@ -1,0 +1,11 @@
+# AWS
+
+## Required environment variables
+
+These environment variables are not required when running inside AWS services, like EC2 or lambdas. [Roles are configured in infrastructure](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html).
+
+| Name                        | Default            | Description                                                                    |
+| --------------------------- | ------------------ | ------------------------------------------------------------------------------ |
+| AWS_ACCESS_KEY_ID           |                    | The AWS key ID.                 |
+| AWS_REGION                  |                    | The AWS region.                  |
+| AWS_SECRET_ACCESS_KEY       |                    | The AWS access key.              |

--- a/aws.md
+++ b/aws.md
@@ -1,11 +1,7 @@
 # AWS
 
-## Required environment variables
+## Configuring access 
 
-These are not required when running inside AWS services, like EC2 or lambdas. [Roles are configured in infrastructure](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html).
+Developing locally: [Configure your environment to communicate with AWS through access keys](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html). 
 
-| Name                        | Default            | Description                                                                    |
-| --------------------------- | ------------------ | ------------------------------------------------------------------------------ |
-| AWS_ACCESS_KEY_ID           |                    | The AWS key ID.                 |
-| AWS_REGION                  |                    | The AWS region.                  |
-| AWS_SECRET_ACCESS_KEY       |                    | The AWS access key.              |
+Running inside AWS services, like EC2 or lambdas: Access keys  **shouldn't be used**.  [Permissions are granted by roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html), which are configured in [infrastructure](https://github.com/elastic-ipfs/infrastructure).

--- a/aws.md
+++ b/aws.md
@@ -2,7 +2,7 @@
 
 ## Required environment variables
 
-These environment variables are not required when running inside AWS services, like EC2 or lambdas. [Roles are configured in infrastructure](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html).
+These are not required when running inside AWS services, like EC2 or lambdas. [Roles are configured in infrastructure](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html).
 
 | Name                        | Default            | Description                                                                    |
 | --------------------------- | ------------------ | ------------------------------------------------------------------------------ |


### PR DESCRIPTION
Centralizing global AWS information to avoid confusion when configuring app specific environment variables. Subrepo documents will link to this one.